### PR TITLE
s/arl/develersrl

### DIFF
--- a/console_test.go
+++ b/console_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/arl/zerolog"
+	"github.com/develersrl/zerolog"
 )
 
 func ExampleConsoleWriter_Write() {

--- a/diode/diode.go
+++ b/diode/diode.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/arl/zerolog/diode/internal/diodes"
+	"github.com/develersrl/zerolog/diode/internal/diodes"
 )
 
 var bufPool = &sync.Pool{

--- a/diode/diode_example_test.go
+++ b/diode/diode_example_test.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/arl/zerolog"
-	"github.com/arl/zerolog/diode"
+	"github.com/develersrl/zerolog"
+	"github.com/develersrl/zerolog/diode"
 )
 
 func ExampleNewWriter() {

--- a/diode/diode_test.go
+++ b/diode/diode_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/arl/zerolog"
-	"github.com/arl/zerolog/diode"
-	"github.com/arl/zerolog/internal/cbor"
+	"github.com/develersrl/zerolog"
+	"github.com/develersrl/zerolog/diode"
+	"github.com/develersrl/zerolog/internal/cbor"
 )
 
 func TestNewWriter(t *testing.T) {

--- a/encoder_cbor.go
+++ b/encoder_cbor.go
@@ -5,7 +5,7 @@ package zerolog
 // This file contains bindings to do binary encoding.
 
 import (
-	"github.com/arl/zerolog/internal/cbor"
+	"github.com/develersrl/zerolog/internal/cbor"
 )
 
 var (

--- a/encoder_json.go
+++ b/encoder_json.go
@@ -6,7 +6,7 @@ package zerolog
 // JSON encoded byte stream.
 
 import (
-	"github.com/arl/zerolog/internal/json"
+	"github.com/develersrl/zerolog/internal/json"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,1 @@
-module github.com/arl/zerolog
+module github.com/develersrl/zerolog

--- a/hlog/hlog.go
+++ b/hlog/hlog.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/arl/zerolog"
-	"github.com/arl/zerolog/log"
+	"github.com/develersrl/zerolog"
+	"github.com/develersrl/zerolog/log"
 	"github.com/rs/xid"
 	"github.com/zenazn/goji/web/mutil"
 )

--- a/hlog/hlog_example_test.go
+++ b/hlog/hlog_example_test.go
@@ -9,8 +9,8 @@ import (
 
 	"net/http/httptest"
 
-	"github.com/arl/zerolog"
-	"github.com/arl/zerolog/hlog"
+	"github.com/develersrl/zerolog"
+	"github.com/develersrl/zerolog/hlog"
 )
 
 // fake alice to avoid dep

--- a/hlog/hlog_test.go
+++ b/hlog/hlog_test.go
@@ -14,8 +14,8 @@ import (
 
 	"net/http/httptest"
 
-	"github.com/arl/zerolog"
-	"github.com/arl/zerolog/internal/cbor"
+	"github.com/develersrl/zerolog"
+	"github.com/develersrl/zerolog/internal/cbor"
 )
 
 func decodeIfBinary(out *bytes.Buffer) string {

--- a/internal/cbor/examples/genLog.go
+++ b/internal/cbor/examples/genLog.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/arl/zerolog"
+	"github.com/develersrl/zerolog"
 )
 
 func writeLog(fname string, count int, useCompress bool) {

--- a/journald/journald.go
+++ b/journald/journald.go
@@ -23,9 +23,9 @@ import (
 	"io"
 	"strings"
 
-	"github.com/arl/zerolog"
-	"github.com/arl/zerolog/internal/cbor"
 	"github.com/coreos/go-systemd/journal"
+	"github.com/develersrl/zerolog"
+	"github.com/develersrl/zerolog/internal/cbor"
 )
 
 const defaultJournalDPrio = journal.PriNotice

--- a/journald/journald_test.go
+++ b/journald/journald_test.go
@@ -2,8 +2,8 @@
 
 package journald_test
 
-import "github.com/arl/zerolog"
-import "github.com/arl/zerolog/journald"
+import "github.com/develersrl/zerolog"
+import "github.com/develersrl/zerolog/journald"
 
 func ExampleNewJournalDWriter() {
 	log := zerolog.New(journald.NewJournalDWriter())

--- a/log.go
+++ b/log.go
@@ -2,12 +2,12 @@
 //
 // A global Logger can be use for simple logging:
 //
-//     import "github.com/arl/zerolog/log"
+//     import "github.com/develersrl/zerolog/log"
 //
 //     log.Info().Msg("hello world")
 //     // Output: {"time":1494567715,"level":"info","message":"hello world"}
 //
-// NOTE: To import the global logger, import the "log" subpackage "github.com/arl/zerolog/log".
+// NOTE: To import the global logger, import the "log" subpackage "github.com/develersrl/zerolog/log".
 //
 // Fields can be added to log messages:
 //

--- a/log/log.go
+++ b/log/log.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/arl/zerolog"
+	"github.com/develersrl/zerolog"
 )
 
 // Logger is the global logger.

--- a/log/log_example_test.go
+++ b/log/log_example_test.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/arl/zerolog"
-	"github.com/arl/zerolog/log"
+	"github.com/develersrl/zerolog"
+	"github.com/develersrl/zerolog/log"
 )
 
 // setup would normally be an init() function, however, there seems

--- a/log_example_test.go
+++ b/log_example_test.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/arl/zerolog"
+	"github.com/develersrl/zerolog"
 )
 
 func ExampleNew() {


### PR DESCRIPTION
Replace all import namespaces from previous fork on `arl` to this fork `develersrl`.

In order to present a PR to upstream `rs`, this would require:
- a clean explaination of the feature, addition of per-category log levels
- documentation (nothing done on that level for now)
- way more tests and benchmarks, to be on par with upstream
- obviously putting all the import and package names back to the original `rs/zerolog`
